### PR TITLE
Improving GraphQL type handling and upgrading testng

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile 'javax.validation:validation-api:1.1.0.Final'
     compile 'com.graphql-java:graphql-java:17.2'
     compile 'com.graphql-java:graphql-java-extended-scalars:17.0'
-
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
 
     // OSGi
     compileOnly 'org.osgi:org.osgi.core:6.0.0'
@@ -64,7 +64,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component:1.3.0'
     compileOnly 'biz.aQute.bnd:biz.aQute.bndlib:3.2.0'
 
-    testCompile 'org.testng:testng:6.9.10'
+    testCompile 'org.testng:testng:7.4.0'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'org.mockito:mockito-core:2.+'
 }

--- a/src/main/java/graphql/annotations/type/GraphQLUndefined.java
+++ b/src/main/java/graphql/annotations/type/GraphQLUndefined.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations.type;
+
+import graphql.schema.GraphQLSchemaElement;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeVisitor;
+import graphql.schema.SchemaElementChildrenContainer;
+import graphql.util.TraversalControl;
+import graphql.util.TraverserContext;
+
+import java.util.List;
+
+public class GraphQLUndefined implements GraphQLType {
+    @Override
+    public List<GraphQLSchemaElement> getChildren() {
+        return GraphQLType.super.getChildren();
+    }
+
+    @Override
+    public SchemaElementChildrenContainer getChildrenWithTypeReferences() {
+        return GraphQLType.super.getChildrenWithTypeReferences();
+    }
+
+    @Override
+    public GraphQLSchemaElement withNewChildren(SchemaElementChildrenContainer newChildren) {
+        return GraphQLType.super.withNewChildren(newChildren);
+    }
+
+    @Override
+    public TraversalControl accept(TraverserContext<GraphQLSchemaElement> context, GraphQLTypeVisitor visitor) {
+        return null;
+    }
+
+    @Override
+    public GraphQLSchemaElement copy() {
+        return new GraphQLUndefined();
+    }
+}

--- a/src/test/java/graphql/annotations/GraphQLInputTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInputTest.java
@@ -12,6 +12,19 @@
  */
 package graphql.annotations;
 
+import static graphql.annotations.AnnotationsSchemaCreator.newAnnotationsSchema;
+import static graphql.schema.GraphQLSchema.newSchema;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.TypeResolutionEnvironment;
@@ -20,18 +33,11 @@ import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeResolver;
 import graphql.annotations.processor.GraphQLAnnotations;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
-import graphql.schema.*;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static graphql.annotations.AnnotationsSchemaCreator.newAnnotationsSchema;
-import static graphql.schema.GraphQLSchema.newSchema;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLNamedType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.TypeResolver;
 
 @SuppressWarnings("unchecked")
 public class GraphQLInputTest {
@@ -123,6 +129,32 @@ public class GraphQLInputTest {
         }
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public static class AnotherCode {
+
+        public AnotherCode(@GraphQLName("firstField") Optional<String> one, @GraphQLName("secondField") String two) {
+            this.firstField = one;
+            this.secondField = two;
+        }
+
+        @GraphQLField
+        public Optional<String> firstField;
+
+        @GraphQLField
+        private final String secondField;
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public static class AnotherCodeWithSingleField {
+
+        public AnotherCodeWithSingleField(@GraphQLName("one") Optional<String> one) {
+            this.field = one;
+        }
+
+        @GraphQLField
+        public Optional<String> field;
+    }
+
     public static class Code {
         public Code(@GraphQLName("map") HashMap map) {
             this.firstField = (String) map.get("firstField");
@@ -133,6 +165,33 @@ public class GraphQLInputTest {
         public String firstField;
         @GraphQLField
         public String secondField;
+    }
+
+    public static class QueryUndefinedParameter {
+
+        @SuppressWarnings({"unused", "OptionalAssignedToNull"})
+        @GraphQLField
+        public String something(@GraphQLName("code") AnotherCode code) {
+            return (code.firstField != null ? code.firstField.orElse("") : "") + code.secondField;
+        }
+
+        @SuppressWarnings({"unused", "OptionalAssignedToNull"})
+        @GraphQLField
+        public String somethingWithOneField(@GraphQLName("code") AnotherCodeWithSingleField code) {
+            return code.field != null ? code.field.orElse("") : "was undefined";
+        }
+
+        @SuppressWarnings({"unused", "OptionalAssignedToNull"})
+        @GraphQLField
+        public String otherthing(@GraphQLName("code") AnotherCode code) {
+            return (code.firstField != null ? code.firstField.orElse("") : "") + code.secondField;
+        }
+
+        @SuppressWarnings({"unused", "OptionalAssignedToNull", "OptionalUsedAsFieldOrParameterType"})
+        @GraphQLField
+        public String listthings(@GraphQLName("codes") Optional<List<AnotherCode>> code) {
+            return code == null ? "was null" : (code.map(anotherCodes -> "code was " + anotherCodes.size()).orElse("was empty"));
+        }
     }
 
     public static class QueryMultipleDefinitions {
@@ -189,6 +248,19 @@ public class GraphQLInputTest {
         ExecutionResult result = graphQL.execute("{ object { value(input:{key:\"test\"}) } }", new Query());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, Map<String, String>>) result.getData()).get("object").get("value"), "testa");
+    }
+
+    @Test
+    public void queryWithUndefinableParameters() {
+        GraphQLSchema schema = newAnnotationsSchema().query(QueryUndefinedParameter.class).build();
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ something(code: {firstField:\"a\",secondField:\"b\"}) otherthing(code: {secondField:\"c\"}) listthings somethingWithOneField(code: {}) }", new QueryUndefinedParameter());
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, String>) result.getData()).get("something"), "ab");
+        assertEquals(((Map<String, String>) result.getData()).get("otherthing"), "c");
+        assertEquals(((Map<String, String>) result.getData()).get("listthings"), "was null");
+        assertEquals(((Map<String, String>) result.getData()).get("somethingWithOneField"), "was undefined");
     }
 
     @Test


### PR DESCRIPTION
# Partial update to entities
The purpose of this PR is to enable updation of selective entity fields. By introducing `Optional`, it also differentiates `null` from `undefined`

Let's assume an entity with 5 fields and the requirement is to update only one field to `null`. We can set the value of that field to `null` and omit other fields in a mutation query.

# Changelog
- Fixing import issues with `javax.xml.bind.DatatypeConverter`
- Bump testng version from `6.9.10` to `7.4.0`
- New `GraphQLUndefined` type
- Following improvements in `MethodDataFetcher`:
    1. Improved `Nullable` handling using `Optional`
    2. Handle `Optional` field types
    3. Support `RawType` in additional to `WrpperType`
- `GraphQLInputTest` updated to test `Optional` field types in GraphQL queries